### PR TITLE
Modification of \fullFrameMovie command

### DIFF
--- a/demo/pdfpc-video-example/pdfpc-commands.sty
+++ b/demo/pdfpc-video-example/pdfpc-commands.sty
@@ -34,7 +34,7 @@
             \centering
             \vbox to 0.95\paperheight {
                 \vfil{
-                    \href{run:#2?autostart&#1}{\includegraphics[width=\paperwidth,height=0.95\paperheight,keepaspectratio]{#3}}
+                    \href{run:#2?#1}{\includegraphics[width=\paperwidth,height=0.95\paperheight,keepaspectratio]{#3}}
                 }
                 \vfil
             }


### PR DESCRIPTION
The default behavior (autostart&loop) is given as a default option. No need to use autostart in the \href command, which blocks on-click behavior. See [this Stack Exchange issue](https://tex.stackexchange.com/q/305515/46718).